### PR TITLE
A Small Improvment

### DIFF
--- a/Adafruit_LSM303.cpp
+++ b/Adafruit_LSM303.cpp
@@ -23,10 +23,12 @@ bool Adafruit_LSM303::begin()
 Serial.println("Wire");
 
   // Enable the accelerometer
-  write8(LSM303_ADDRESS_ACCEL, LSM303_REGISTER_ACCEL_CTRL_REG1_A, 0x27);
+  if (!write8(LSM303_ADDRESS_ACCEL, LSM303_REGISTER_ACCEL_CTRL_REG1_A, 0x27))
+    return false;
   
   // Enable the magnetometer
-  write8(LSM303_ADDRESS_MAG, LSM303_REGISTER_MAG_MR_REG_M, 0x00);
+  if (!write8(LSM303_ADDRESS_MAG, LSM303_REGISTER_MAG_MR_REG_M, 0x00))
+    return false;
 
   return true;
 }
@@ -91,12 +93,12 @@ void Adafruit_LSM303::setMagGain(lsm303MagGain gain)
 /***************************************************************************
  PRIVATE FUNCTIONS
  ***************************************************************************/
-void Adafruit_LSM303::write8(byte address, byte reg, byte value)
+byte Adafruit_LSM303::write8(byte address, byte reg, byte value)
 {
   Wire.beginTransmission(address);
   Wire.write(reg);
   Wire.write(value);
-  Wire.endTransmission();
+  return Wire.endTransmission();
 }
 
 byte Adafruit_LSM303::read8(byte address, byte reg)

--- a/Adafruit_LSM303.h
+++ b/Adafruit_LSM303.h
@@ -115,7 +115,7 @@ class Adafruit_LSM303
     lsm303AccelData accelData;    // Last read accelerometer data will be available here
     lsm303MagData magData;        // Last read magnetometer data will be available here
 
-    void write8(byte address, byte reg, byte value);
+    byte write8(byte address, byte reg, byte value);
     byte read8(byte address, byte reg);
 
   private:


### PR DESCRIPTION
Thank you for the great hardware, libraries, examples and the awesome articles on the Learning System!

The begin() method always returned true regardless of the actual message write results. This change updates write8() to return the results of the Wire.endTransmission() method. This allows callers to check for non-zero error values. The begin() method was updated to use this new return value to return an accurate result.
